### PR TITLE
scripts/nuke: full blown copy over

### DIFF
--- a/nuke.sh
+++ b/nuke.sh
@@ -4,25 +4,28 @@
 # system app nuker whiteout module creator
 # this is modified from mountify's whiteout creator
 # No warranty.
-
 PATH=/data/adb/ap/bin:/data/adb/ksu/bin:/data/adb/magisk:$PATH
 MODDIR="/data/adb/modules/system_app_nuker"
+MODULES_UPDATE_DIR="/data/adb/modules_update/system_app_nuker"
 TEXTFILE="$MODDIR/nuke_list.txt"
 
-# straight up use moddir
-[ -d "$MODDIR/system" ] && rm -rf "$MODDIR/system"
-mkdir -p "$MODDIR/system"
-busybox chcon --reference="/system" "$MODDIR/system"
+# revamped routine
+# here we copy over all the module files to modules_update folder.
+# this is better than deleting system over and over
+# also this way manager handles the update.
+# this can avoid persistence issues too
+
+# create folder if it doesnt exist
+[ ! -d "$MODULES_UPDATE_DIR" ] && mkdir -p "$MODULES_UPDATE_DIR"
+busybox chcon --reference="/system" "$MODULES_UPDATE_DIR"
 
 whiteout_create_systemapp() {
-	echo "$MODDIR${1%/*}"
-	echo "$MODDIR$1" 
-	mkdir -p "$MODDIR${1%/*}"
-	rm -rf "$MODDIR${1%/*}"
-  	busybox mknod "$MODDIR${1%/*}" c 0 0
-  	busybox chcon --reference="/system" "$MODDIR$1"  
+	mkdir -p "$MODULES_UPDATE_DIR${1%/*}"
+	rm -rf "$MODULES_UPDATE_DIR${1%/*}"
+  	busybox mknod "$MODULES_UPDATE_DIR${1%/*}" c 0 0
+  	busybox chcon --reference="/system" "$MODULES_UPDATE_DIR$1"  
   	# not really required, mountify() does NOT even copy the attribute but ok
-  	busybox setfattr -n trusted.overlay.whiteout -v y "$MODDIR$1"
+  	busybox setfattr -n trusted.overlay.whiteout -v y "$MODULES_UPDATE_DIR$1"
   	chmod 644 "$MODDIR$1"
 }
 
@@ -30,6 +33,7 @@ for line in $( sed '/#/d' "$TEXTFILE" ); do
 	apk_path=$(pm path "$line" 2>/dev/null | sed 's/package://')
 
 	# if the APK is in /data/app/, uninstall first
+	# this might be better flagged later.
 	if echo "$apk_path" | grep -q "^/data/app/"; then
 		echo "[*] Detected updated system app for $line in /data/app/, uninstalling update..."
 		pm uninstall -k --user 0 "$line"
@@ -47,7 +51,7 @@ for line in $( sed '/#/d' "$TEXTFILE" ); do
 
 	# Create whiteout for apk_path
 	whiteout_create_systemapp "$apk_path" > /dev/null 2>&1
-	ls "$MODDIR$line" 2>/dev/null
+	ls "$MODULES_UPDATE_DIR$line" 2>/dev/null
 done
 
 # special dirs
@@ -63,21 +67,28 @@ vendor"
 # this assumes magic mount
 # handle overlayfs KSU later?
 for dir in $targets; do 
-	if [ -d /$dir ] && [ ! -L /$dir ] && [ -d "$MODDIR/system/$dir" ]; then
-		if [ -L "$MODDIR/$dir" ]; then
+	if [ -d /$dir ] && [ ! -L /$dir ] && [ -d "$MODULES_UPDATE_DIR/system/$dir" ]; then
+		if [ -L "$MODULES_UPDATE_DIR/$dir" ]; then
 			# Check if the symlink points to the correct location
-			if [ $(readlink -f $MODDIR/$dir) != $(realpath $MODDIR/system/$dir) ]; then
+			if [ $(readlink -f $MODULES_UPDATE_DIR/$dir) != $(realpath $MODULES_UPDATE_DIR/system/$dir) ]; then
 				echo "[!] Incorrect symlink for /$dir, fixing..."
-				rm -f $MODDIR/$dir
-				ln -sf ./system/$dir $MODDIR/$dir
+				rm -f $MODULES_UPDATE_DIR/$dir
+				ln -sf ./system/$dir $MODULES_UPDATE_DIR/$dir
 			else
 				echo "[+] Symlink for /$dir is correct, skipping..."
 			fi
 		else
 			echo "[+] Creating symlink for /$dir"
-			ln -sf ./system/$dir $MODDIR/$dir
+			ln -sf ./system/$dir $MODULES_UPDATE_DIR/$dir
 		fi
 	fi
 done
+
+# now we copy over everything from MODDIR to MODULES_UPDATE_DIR
+# the asterisk is important!!
+cp -Lrf "$MODDIR"/* "$MODULES_UPDATE_DIR"
+
+# now we flag old module for update
+touch "$MODDIR/update"
 
 # EOF


### PR DESCRIPTION
revamped routine
here we copy over all the module files to modules_update folder.
this is better than deleting system over and over
also this way manager handles the update.
this can avoid persistence issues too