### PR TITLE
scripts/nuke: fix missed chmod target

### DIFF
--- a/nuke.sh
+++ b/nuke.sh
@@ -66,11 +66,12 @@ whiteout_create_systemapp() {
     path="$1"
     echo "$path" | grep -q "/system/" || path="/system$1"
     mkdir -p "$MODULES_UPDATE_DIR${path%/*}"
+    chmod 644 "$MODULES_UPDATE_DIR${path%/*}"
     busybox mknod "$MODULES_UPDATE_DIR$path" c 0 0
     busybox chcon --reference="/system" "$MODULES_UPDATE_DIR$path"
     # not really required, mountify() does NOT even copy the attribute but ok
     busybox setfattr -n trusted.overlay.whiteout -v y "$MODULES_UPDATE_DIR$path"
-    chmod 644 "$MODDIR$path"
+    chmod 644 "$MODULES_UPDATE_DIR$path"
 }
 
 nuke_system_apps() {


### PR DESCRIPTION
this can cause issues as permission will likely be 600 on certain dirs
correct it.