### PR TITLE
dummy_zip: fixups

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,9 @@ jobs:
 
     - name: Create dummy zip
       run: |
-        cp module/module.prop module/dummy_zip/
         cd module/dummy_zip
-        zip -r dummy.zip module.prop META-INF
-        cp dummy.zip ../
+        zip -r dummy.zip *
+        mv dummy.zip ../
       
     - name: Upload artifact
       uses: actions/upload-artifact@v4

--- a/module/dummy_zip/module.prop
+++ b/module/dummy_zip/module.prop
@@ -1,4 +1,4 @@
-id=system_app_nuker_dummy
+id=system_app_nuker
 name=Dummy - I'll Be Gone Soon!
 version=v0.0
 versionCode=0

--- a/module/nuke.sh
+++ b/module/nuke.sh
@@ -33,8 +33,8 @@ if [ ! "$DUMMYZIP" = "true" ] && [ ! "$update" = true ]; then
         magisk --install-module "$MODDIR/dummy.zip"
     else
         echo "am I trippin or you are using some unknown root manager?"
-        exit 1
     fi
+    exit 0
 fi
 
 whiteout_create_systemapp() {


### PR DESCRIPTION
include customize.sh in the zip, or we just zip it all
restore old id to prevent creating a different module