### PR TITLE
Symlinks bug fix

### DIFF
--- a/module/webroot/scripts/util.js
+++ b/module/webroot/scripts/util.js
@@ -144,7 +144,7 @@ export function setupSearch() {
 // Handle link within webui
 async function linkFile() {
     try {
-        await ksuExec(`[ -L "/data/adb/modules/system_app_nuker/webroot/link" ] || ln -s /data/adb/system_app_nuker /data/adb/modules/system_app_nuker/webroot/link`);
+        await ksuExec(`[ -L "/data/adb/modules/system_app_nuker/webroot/link" ] || rm -r /data/adb/modules/system_app_nuker/webroot/link && ln -s /data/adb/system_app_nuker /data/adb/modules/system_app_nuker/webroot/link`);
     } catch (error) {
         console.error("Failed to link file:", error);
     }


### PR DESCRIPTION
After some testing, I noticed that on my Samsung S23 Ultra (rooted with SukiSU-Ultra GKI), this module breaks because its Web UI becomes unusable after the first reboot.

On my device, the symbolic link at `/data/adb/modules/system_app_nuker/webroot/link` breaks after reboot and turns into a regular folder. As a result, when the Web UI is opened a second time:
- The check `[ -L "/data/adb/modules/system_app_nuker/webroot/link" ]` fails.
- Since the folder already exists, a new symlink is created inside the folder with the name system_app_nuker.

This behavior prevents the Web UI from functioning properly after reboot as the app_list.json and nuke_list.json remains the same from the Web UI's point of view.

There might be a better way to fix this issue, but I came up with a simple solution: using a single `rm -r` to remove the folder before creating the new symlink. After further testing, the issue no longer occurs on my device.