### PR TITLE
fix: redirect stdin for pm calls in loops

### DIFF
--- a/module/nuke.sh
+++ b/module/nuke.sh
@@ -85,13 +85,13 @@ is_apk_path() {
 }
 
 get_apk_path() {
-    pm path "$1" 2>/dev/null |
+    pm path "$1" </dev/null 2>/dev/null |
         sed -n 's|^package:\(/.*\.apk\)$|\1|p' |
         head -n1
 }
 
 get_factory_apk_path() {
-    pm list packages -f -s -u --factory-only "$1" 2>/dev/null |
+    pm list packages -f -s -u --factory-only "$1" </dev/null 2>/dev/null |
         awk -F= -v pkg="$1" '$NF == pkg {
             sub(/^package:/, "", $1)
             if ($1 ~ /^\/.*\.apk$/) {
@@ -103,8 +103,8 @@ get_factory_apk_path() {
 
 uninstall_for_user() {
     package_name="$1"
-    pm list packages "$package_name" 2>/dev/null | grep -qx "package:$package_name" || return 0
-    pm uninstall --user 0 "$package_name" >/dev/null 2>&1
+    pm list packages "$package_name" </dev/null 2>/dev/null | grep -qx "package:$package_name" || return 0
+    pm uninstall --user 0 "$package_name" </dev/null >/dev/null 2>&1
 }
 
 append_line() {
@@ -289,9 +289,9 @@ prepare_nuke_list() {
             factory_path=$(get_factory_apk_path "$package_name")
             is_apk_path "$factory_path" && saved_path="$factory_path"
         fi
-        if echo "$apk_path" | grep -q '^/data/app' && pm list packages -s | grep -qx "package:$package_name"; then
+        if echo "$apk_path" | grep -q '^/data/app' && pm list packages -s </dev/null | grep -qx "package:$package_name"; then
             if [ "$update" = true ]; then
-                pm uninstall-system-updates "$package_name" >/dev/null 2>&1 || true
+                pm uninstall-system-updates "$package_name" </dev/null >/dev/null 2>&1 || true
                 apk_path=$(get_apk_path "$package_name")
                 if echo "$apk_path" | grep -q '^/data/app'; then
                     uninstall_for_user "$package_name" || { rm -f "$list_tmp"; return 1; }
@@ -358,14 +358,14 @@ nuke_system_apps() {
     # remove any updates for the apps being nuked
     for package_name in $(grep -Ev "^$|^#" "$REMOVE_LIST" | awk '{print $1}'); do
         # check if it's a system app that has been updated
-        if pm list packages -s | grep -qx "package:$package_name" && get_apk_path "$package_name" | grep -q "/data/app"; then
-            pm uninstall-system-updates "$package_name" >/dev/null 2>&1 || true
+        if pm list packages -s </dev/null | grep -qx "package:$package_name" && get_apk_path "$package_name" | grep -q "/data/app"; then
+            pm uninstall-system-updates "$package_name" </dev/null >/dev/null 2>&1 || true
         fi
     done
 
     if [ "$uninstall_only_mode" = "true" ]; then
         for package_name in $(grep -Ev "^$|^#" "$REMOVE_LIST" | awk '{print $1}'); do
-            pm uninstall --user 0 "$package_name" >/dev/null 2>&1 || true
+            pm uninstall --user 0 "$package_name" </dev/null >/dev/null 2>&1 || true
         done
     else
         # whiteout creation. the list is "<pkg> <path> <label>" — rewrite it
@@ -427,8 +427,8 @@ nuke_system_apps() {
     if [ -f "$REMOVE_LIST.old" ]; then
         for pkg in $(grep -Ev "^$|^#" "$REMOVE_LIST.old" | awk '{print $1}'); do
             awk -v pkg="$pkg" '$1 == pkg { found=1 } END { exit !found }' "$REMOVE_LIST" 2>/dev/null && continue
-            pm install-existing "$pkg" >/dev/null 2>&1 || restore_success="false"
-            pm enable "$pkg" >/dev/null 2>&1 || restore_success="false"
+            pm install-existing "$pkg" </dev/null >/dev/null 2>&1 || restore_success="false"
+            pm enable "$pkg" </dev/null >/dev/null 2>&1 || restore_success="false"
         done
     fi
     if [ "$uninstall_only_mode" = "true" ] && [ "$restore_success" = "true" ]; then

--- a/module/service.sh
+++ b/module/service.sh
@@ -113,8 +113,8 @@ if [ -s "$REMOVE_LIST.old" ]; then
         pkg=$(echo "$old_line" | awk '{print $1}')
         awk -v pkg="$pkg" '$1 == pkg { found=1 } END { exit !found }' "$REMOVE_LIST" 2>/dev/null && continue
         restore_success=true
-        pm install-existing "$pkg" >/dev/null 2>&1 || restore_success=false
-        pm enable "$pkg" >/dev/null 2>&1 || restore_success=false
+        pm install-existing "$pkg" </dev/null >/dev/null 2>&1 || restore_success=false
+        pm enable "$pkg" </dev/null >/dev/null 2>&1 || restore_success=false
         [ "$restore_success" = true ] || echo "$old_line" >> "$FAILED_RESTORES" || exit 1
     done < "$REMOVE_LIST.old"
 fi
@@ -122,7 +122,7 @@ fi
 # make sure app is uninstalled if user is switching to uninstall only mode
 if [ -s "$REMOVE_LIST" ] && [ "$uninstall_only_mode" = "true" ]; then
     for pkg in $(grep -Ev "^$|^#" "$REMOVE_LIST" | awk '{print $1}'); do
-        pm uninstall --user 0 "$pkg" >/dev/null 2>&1 || true
+        pm uninstall --user 0 "$pkg" </dev/null >/dev/null 2>&1 || true
     done
 fi
 

--- a/module/uninstall.sh
+++ b/module/uninstall.sh
@@ -6,10 +6,10 @@ REMOVE_LIST="$PERSIST_DIR/nuke_list.txt.old"
 # Install apps that are uninstalled
 restore_success=true
 for pkg in $(grep -Ev "^$|^#" "$REMOVE_LIST" | awk '{print $1}'); do
-    if ! pm path "$pkg" >/dev/null 2>&1; then
-        pm install-existing "$pkg" >/dev/null 2>&1 || restore_success=false
+    if ! pm path "$pkg" </dev/null >/dev/null 2>&1; then
+        pm install-existing "$pkg" </dev/null >/dev/null 2>&1 || restore_success=false
     fi
-    pm enable "$pkg" >/dev/null 2>&1 || restore_success=false
+    pm enable "$pkg" </dev/null >/dev/null 2>&1 || restore_success=false
 done
 
 if [ "$restore_success" = true ]; then


### PR DESCRIPTION
Prevent pm / cmd package from consuming the loop's file descriptor on stdin when iterating through package lists in while loops.

Fixes an issue where `get_apk_path` (and other `pm` calls) fail when executed inside `while read ... < file` loops, resulting in missing APK paths in `nuke_list.txt` and preventing whiteout nodes from being created.

When iterating through `nuke_list.txt` in a `while read` loop:
```sh
while IFS= read -r line || [ -n "$line" ]; do
    apk_path=$(get_apk_path "$package_name")
done < "$REMOVE_LIST"
```

Subprocesses invoked inside the loop inherit the open file descriptor on stdin.
On modern Android versions /system/bin/pm executes /system/bin/cmd package "$@", cmd passes stdin over Binder to system_server. When stdin is connected to an open text file with pending lines, cmd consumes/drains bytes from the stream or fails on initialization. Because stderr is redirected (2>/dev/null), the failure is silent, causing apk_path to be empty (""), which writes pathless lines (<pkg>  <label>) and skips whiteout_create.

This fix explicitly isolates stdin with </dev/null on pm invocations inside loops. Tested on a real (own) device -- fixed inconsistent failures where nuking produced corrupted nuke_list.txt(.old) without APK paths, such as:

`com.facebook.katana  Facebook`
instead of expected:
`com.facebook.katana /product/app/app-com-facebook-katana-local-stub/app-com-facebook-katana-local-stub.apk Facebook`